### PR TITLE
Add support for parsing .vtt files where there are no characters to r…

### DIFF
--- a/Sources/SimpleSubtitles/Interactor/Parsers/WebVTTParser.swift
+++ b/Sources/SimpleSubtitles/Interactor/Parsers/WebVTTParser.swift
@@ -2,7 +2,7 @@ import Foundation
 import SubtitlesInterface
 
 class WebVTTParser: SubtitlesParserProtocol {
-    private static let regexPattern = #"(?m)^(\d{1,2}:\d{2}:\d{2}\.\d+) +--> +(\d{1,2}:\d{2}:\d{2}\.\d+).*[\r\n]+\s*(?s)((?:(?!\r?\n\r?\n).)*)"#
+    private static let regexPattern = #"(?m)^((\d{1,2}:)?\d{2}:\d{2}\.\d+) +--> +((\d{1,2}:)?\d{2}:\d{2}\.\d+).*[\r\n]+\s*(?s)((?:(?!\r?\n\r?\n).)*)"#
     private static let regexPattern2 = #"([0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+)"#
     
     func parse(string: String) -> SubtitleInformation? {
@@ -19,9 +19,9 @@ class WebVTTParser: SubtitlesParserProtocol {
             if match.numberOfRanges >= 3,
                let timeStartRange = Range(match.range(at: 1),
                                      in: string),
-               let timeEndRange = Range(match.range(at: 2),
+               let timeEndRange = Range(match.range(at: 3),
                                    in: string),
-               let linesRange = Range(match.range(at: 3),
+               let linesRange = Range(match.range(at: 5),
                                   in: string) {
                 let timeStart = string[timeStartRange].convertToTimeInterval()
                 let timeEnd = string[timeEndRange].convertToTimeInterval()


### PR DESCRIPTION
This library was not working for me because the parser would fail with .vtt files where if the timestamp was below one hour there would be no 00: characters. This PR changes the regex to handle that situation.